### PR TITLE
Add option to disable unchatter for individual keys

### DIFF
--- a/KeyboardUnchatter/App.config
+++ b/KeyboardUnchatter/App.config
@@ -1,15 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="KeyboardChatterFix.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+             <section name="KeyboardUnchatter.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
     <userSettings>
-        <KeyboardChatterFix.Properties.Settings>
+        <KeyboardUnchatter.Properties.Settings>
             <setting name="chatterThreshold" serializeAs="String">
                 <value>20</value>
             </setting>
@@ -19,6 +19,11 @@
             <setting name="activateOnLaunch" serializeAs="String">
                 <value>True</value>
             </setting>
-        </KeyboardChatterFix.Properties.Settings>
+            <setting name="disabledKeys" serializeAs="Xml">
+                <value>
+                    <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+                </value>
+            </setting>
+        </KeyboardUnchatter.Properties.Settings>
     </userSettings>
 </configuration>

--- a/KeyboardUnchatter/DataGridController.cs
+++ b/KeyboardUnchatter/DataGridController.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace KeyboardUnchatter
@@ -84,25 +80,28 @@ namespace KeyboardUnchatter
         private void UpdateGridCell(KeyData keyData)
         {
             bool cellUpdated = false;
+            var keyPressed = keyData.Key.ToString();
+            var keyDisabled = Properties.Settings.Default.disabledKeys.Contains(keyPressed);
+            int press = keyData.KeyPressedCount;
+            int block = keyData.KeyBlockedCount;
+            var percentage = Math.Floor((float)block / (float)press * 100).ToString() + "%";
+
             for (int a = 0; a < _dataGrid.Rows.Count; ++a)
             {
                 var row = _dataGrid.Rows[a];
+                var keyColumnCell = row.Cells[1];
 
-                if (row.Cells[0].Value != null && row.Cells[0].Value.ToString() == keyData.Key.ToString())
+                if (keyColumnCell.Value != null && keyColumnCell.Value.ToString() == keyPressed)
                 {
-                    int press = keyData.KeyPressedCount;
-                    int block = keyData.KeyBlockedCount;
-
-                    _dataGrid.Rows[a].SetValues(new string[] { keyData.Key.ToString(), press.ToString(), block.ToString(), (Math.Floor((float)block/(float)press*100)).ToString() +"%" });
+                    _dataGrid.Rows[a].SetValues(new object[] { keyDisabled, keyPressed, press.ToString(), block.ToString(), percentage});
                     cellUpdated = true;
+                    break;
                 }
             }
 
             if (!cellUpdated)
             {
-                int press = keyData.KeyPressedCount;
-                int block = keyData.KeyBlockedCount;
-                _dataGrid.Rows.Add(new string[] { keyData.Key.ToString(), press.ToString(), block.ToString(), (Math.Floor((float)block / (float)press)*100).ToString() + "%" });
+                _dataGrid.Rows.Add(new object[] { keyDisabled, keyPressed, press.ToString(), block.ToString(), percentage });
             }
         }
     }

--- a/KeyboardUnchatter/KeyboardMonitor.cs
+++ b/KeyboardUnchatter/KeyboardMonitor.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Windows.Forms;
-using System.Diagnostics;
 
 
 namespace KeyboardUnchatter
@@ -60,6 +58,7 @@ namespace KeyboardUnchatter
             }
             
             var key = _keyStatusList.GetKey(keyPress.KeyCode);
+            var unchatterDisabled = Properties.Settings.Default.disabledKeys.Contains(keyPress.Key.ToString());
 
             if (keyPress.Status == InputHook.KeyStatus.Down)
             {
@@ -69,7 +68,8 @@ namespace KeyboardUnchatter
                 if (lastPressStatus == KeyStatusList.PressStatus.Up &&  key.IsBlocked)
                 {
                     Debug.Log("Key"+ key.KeyCode+" is blocked. Discarding");
-                    return false;
+                    if (!unchatterDisabled)
+                        return false;
                 }
 
                 double timeSpan = key.GetLastPressTimeSpan();
@@ -77,9 +77,12 @@ namespace KeyboardUnchatter
                 if(timeSpan < _chatterTimeMs)
                 {
                     Debug.Log("Key" + key.KeyCode + " timeSpawn is below limit. Blocking");
-                    key.Block();
                     RegisterChatterPress(keyPress.Key);
-                    return false;
+                    if (!unchatterDisabled)
+                    {
+                        key.Block();
+                        return false;
+                    }
                 }
             }
 
@@ -94,7 +97,8 @@ namespace KeyboardUnchatter
                 if (keyWasBlocked && key.GetBlockTimeSpan() < _chatterTimeMs)
                 {
                     Debug.Log("Key" + key.KeyCode + " was blocked");
-                    return false;
+                    if (!unchatterDisabled)
+                        return false;
                 }
                 else
                 {

--- a/KeyboardUnchatter/KeyboardUnchatter.csproj
+++ b/KeyboardUnchatter/KeyboardUnchatter.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>KeyboardUnchatter</RootNamespace>
     <AssemblyName>KeyboardUnchatter</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PublishUrl>publish\</PublishUrl>
@@ -26,6 +26,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -84,6 +85,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="MainWindow.resx">
       <DependentUpon>MainWindow.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/KeyboardUnchatter/MainWindow.Designer.cs
+++ b/KeyboardUnchatter/MainWindow.Designer.cs
@@ -34,6 +34,7 @@
             this._statusPanelLabel = new System.Windows.Forms.Label();
             this._buttonActivate = new System.Windows.Forms.Button();
             this._mainDataGrid = new System.Windows.Forms.DataGridView();
+            this.Disabled = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.Key = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.PressCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ChatterCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -106,9 +107,10 @@
             this._mainDataGrid.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this._mainDataGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this._mainDataGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.Key,
-            this.PressCount,
-            this.ChatterCount,
+                this.Disabled,
+                this.Key,
+                this.PressCount,
+                this.ChatterCount,
             this.FailureRate});
             this._mainDataGrid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
             this._mainDataGrid.Location = new System.Drawing.Point(6, 19);
@@ -118,6 +120,12 @@
             this._mainDataGrid.Size = new System.Drawing.Size(583, 204);
             this._mainDataGrid.TabIndex = 3;
             this._mainDataGrid.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.DataSortCompare);
+            this._mainDataGrid.CellContentClick += this.OnDisabledCheckBox;
+            //
+            // Disabled
+            //
+            this.Disabled.HeaderText = "Disable Unchattering";
+            this.Disabled.Name = "Disabled";
             // 
             // Key
             // 
@@ -322,6 +330,7 @@
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem _exitMenuItem;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn Disabled;
         private System.Windows.Forms.DataGridViewTextBoxColumn Key;
         private System.Windows.Forms.DataGridViewTextBoxColumn PressCount;
         private System.Windows.Forms.DataGridViewTextBoxColumn ChatterCount;

--- a/KeyboardUnchatter/MainWindow.cs
+++ b/KeyboardUnchatter/MainWindow.cs
@@ -1,13 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Diagnostics;
 
 namespace KeyboardUnchatter
 {
@@ -149,6 +142,21 @@ namespace KeyboardUnchatter
             Properties.Settings.Default.Save();
         }
 
+        private void OnDisabledCheckBox(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.ColumnIndex == this.Disabled.Index)
+            {
+                var cell = this._mainDataGrid[e.ColumnIndex, e.RowIndex];
+                var isChecked = !(bool)cell.Value;
+                cell.Value = isChecked; // Toggle checkbox manually, datagrid is in programmatic edit mode
+                string pressedKey = this._mainDataGrid.Rows[e.RowIndex].Cells[1].Value.ToString();
+                if (isChecked)
+                    Properties.Settings.Default.disabledKeys.Add(pressedKey);
+                else
+                    Properties.Settings.Default.disabledKeys.Remove(pressedKey);
+                Properties.Settings.Default.Save();
+            }
+        }
 
         private void DataSortCompare(object sender, DataGridViewSortCompareEventArgs e)
         {

--- a/KeyboardUnchatter/MainWindow.resx
+++ b/KeyboardUnchatter/MainWindow.resx
@@ -129,18 +129,6 @@
   <metadata name="FailureRate.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="Key.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="PressCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ChatterCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="FailureRate.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="_notifyIcon.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/KeyboardUnchatter/Properties/Resources.Designer.cs
+++ b/KeyboardUnchatter/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace KeyboardUnchatter.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/KeyboardUnchatter/Properties/Settings.Designer.cs
+++ b/KeyboardUnchatter/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace KeyboardUnchatter.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.12.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -56,6 +56,19 @@ namespace KeyboardUnchatter.Properties {
             }
             set {
                 this["activateOnLaunch"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsd=\"http://www.w3." +
+            "org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" />")]
+        public global::System.Collections.Specialized.StringCollection disabledKeys {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["disabledKeys"]));
+            }
+            set {
+                this["disabledKeys"] = value;
             }
         }
     }

--- a/KeyboardUnchatter/Properties/Settings.settings
+++ b/KeyboardUnchatter/Properties/Settings.settings
@@ -1,5 +1,5 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="KeyboardChatterFix.Properties" GeneratedClassName="Settings">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="KeyboardUnchatter.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
     <Setting Name="chatterThreshold" Type="System.Decimal" Scope="User">
@@ -10,6 +10,10 @@
     </Setting>
     <Setting Name="activateOnLaunch" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="disabledKeys" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" /&gt;</Value>
     </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
I have added possibility to disable unchatter for individual keys. Its useful for control keys (like you dont want to block CTRL or SHIFT) and for keyboard with volume sliders. Maybe there are more uses.
In the UI, the change is represented by checkbox column.
![image](https://github.com/user-attachments/assets/d07aaaaf-8f85-4961-a6ca-ed39eca084e2)
